### PR TITLE
Maintain new lines within paragraphs

### DIFF
--- a/__tests__/wrap.test.ts
+++ b/__tests__/wrap.test.ts
@@ -16,14 +16,14 @@ the lazy\n\
 dog.')
 })
 
-test('it re-wraps paragraphs longer than the given length', () => {
+test('it keeps new lines in paragraphs longer than the given length', () => {
   const input = 'The quick brown\nfox jumps over the lazy dog.'
   const result = wrap(10, input)
   expect(result).toEqual('The quick\n\
-brown fox\n\
-jumps over\n\
-the lazy\n\
-dog.')
+brown\n\
+fox jumps\n\
+over the\n\
+lazy dog.')
 })
 
 test('it maintains paragraphs shorter than the given length', () => {
@@ -53,21 +53,21 @@ dog.'
   )
 })
 
-test('it re-wraps each paragraph longer than the given length', () => {
+test('it keeps each line longer than the given length', () => {
   const input =
     'The quick brown\nfox jumps over the lazy dog.\n\n\
 The quick brown fox jumps over the\nlazy dog.'
   const result = wrap(10, input)
   expect(result).toEqual(
     'The quick\n\
-brown fox\n\
-jumps over\n\
-the lazy\n\
-dog.\n\n\
+brown\n\
+fox jumps\n\
+over the\n\
+lazy dog.\n\n\
 The quick\n\
 brown fox\n\
 jumps over\n\
-the lazy\n\
-dog.'
+the\n\
+lazy dog.'
   )
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -23579,12 +23579,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.wrap = void 0;
 function wrap(length, text) {
     return text
-        .split('\n\n')
+        .split('\n')
         .map(paragraph => {
-        const words = paragraph.replace('\n', ' ').split(' ');
+        const words = paragraph.split(' ');
         return wrapper(length, words, '');
     })
-        .join('\n\n');
+        .join('\n');
 }
 exports.wrap = wrap;
 function wrapper(length, words, line) {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,11 +1,11 @@
 export function wrap(length: number, text: string): string {
   return text
-    .split('\n\n')
+    .split('\n')
     .map(paragraph => {
-      const words = paragraph.replace('\n', ' ').split(' ')
+      const words = paragraph.split(' ')
       return wrapper(length, words, '')
     })
-    .join('\n\n')
+    .join('\n')
 }
 
 function wrapper(length: number, words: string[], line: string): string {


### PR DESCRIPTION
Some rules include lists in their details which need new lines.