### PR TITLE
build (#49): update nodejs version to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     description: 'Change the working directory'
     required: false
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
This should fix the issue of the nodejs version in the github action being deprecated. See also #49.