### PR TITLE
Upgrade to remove node24 warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     description: 'Change the working directory'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -97,13 +97,13 @@ const runElmReview = async () => {
         silent: true
     };
     await exec.exec(inputElmReview, elmReviewArgs(), options);
-    if (errput.length > 0) {
-        throw Error(errput);
-    }
     try {
         return JSON.parse(output);
     }
     catch (_) {
+        if (errput.length > 0) {
+            throw Error(errput);
+        }
         throw Error(output);
     }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -35,7 +35,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
 const github = __importStar(__nccwpck_require__(5438));
-const command_1 = __nccwpck_require__(7351);
 const action_1 = __nccwpck_require__(1231);
 const wrap_1 = __nccwpck_require__(5372);
 const octokit = new action_1.Octokit();
@@ -129,7 +128,11 @@ const reportErrors = (errors) => {
 };
 function issueError(message, opts) {
     for (const line of message.trim().split('\n')) {
-        (0, command_1.issueCommand)('error', opts, line);
+        core.error(line, {
+            file: opts.file,
+            startLine: opts.line,
+            startColumn: opts.col
+        });
     }
     process.exitCode = core.ExitCode.Failure;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-review-action",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Use elm-review to check code quality",
   "main": "lib/main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,13 +85,12 @@ const runElmReview = async (): Promise<ReviewErrors | CliError> => {
 
   await exec.exec(inputElmReview, elmReviewArgs(), options)
 
-  if (errput.length > 0) {
-    throw Error(errput)
-  }
-
   try {
     return JSON.parse(output)
   } catch (_) {
+    if (errput.length > 0) {
+      throw Error(errput)
+    }
     throw Error(output)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as github from '@actions/github'
-import {issueCommand} from '@actions/core/lib/command'
 import {Octokit, RestEndpointMethodTypes} from '@octokit/action'
 import {wrap} from './wrap'
 
@@ -179,7 +178,11 @@ type ErrorOpts = {
 
 function issueError(message: string, opts: ErrorOpts): void {
   for (const line of message.trim().split('\n')) {
-    issueCommand('error', opts, line)
+    core.error(line, {
+      file: opts.file,
+      startLine: opts.line,
+      startColumn: opts.col
+    })
   }
   process.exitCode = core.ExitCode.Failure
 }


### PR DESCRIPTION
Hey @sparksp, I was trying to get rid of some of the warning noise so I upgrade this.

Here's the warning I'm seeing (for example [in this CI run](https://github.com/dillonkearns/elm-tailwind-classes/actions/runs/23661753297)):

https://github.com/dillonkearns/elm-review-action/actions/runs/23664456948/job/68942875806
<img width="2688" height="502" alt="CleanShot 2026-03-27 at 13 06 01@2x" src="https://github.com/user-attachments/assets/8c783255-82dd-4098-9ffb-5c37e5f5cf37" />

And I was [able to do a run of this upgraded version of `elm-review-action` in a CI check](https://github.com/dillonkearns/elm-review-action/actions/runs/23664456948/job/68942875806) to confirm it works and reports errors successfully:

<img width="3332" height="1532" alt="CleanShot 2026-03-27 at 13 06 27@2x" src="https://github.com/user-attachments/assets/79a273b2-b30c-442d-b7b7-facb62214c8b" />

Happy to adjust things if you have any changes you'd like me to make or anything you'd like to discuss!